### PR TITLE
Refactor allowance get  escapedcat

### DIFF
--- a/src/app/screens/Home/index.tsx
+++ b/src/app/screens/Home/index.tsx
@@ -194,75 +194,65 @@ function Home() {
           </h2>
           {allowance?.payments.length > 0 ? (
             <TransactionsTable
-              transactions={allowance.payments.reduce<Transaction[]>(
-                (acc, payment) => {
-                  if (!payment?.id) return acc;
+              transactions={allowance.payments.map((payment) => {
+                const {
+                  createdAt,
+                  description,
+                  host,
+                  id,
+                  location,
+                  name,
+                  preimage,
+                  totalAmount,
+                  totalFees,
+                } = payment;
 
-                  const {
-                    createdAt,
-                    description,
-                    host,
-                    id,
-                    location,
-                    name,
-                    preimage,
-                    totalAmount,
-                    totalFees,
-                  } = payment;
-
-                  acc.push({
-                    createdAt,
-                    description,
-                    id: `${id}`,
-                    location,
-                    name,
-                    preimage,
-                    host,
-                    totalAmount:
-                      typeof totalAmount === "string"
-                        ? parseInt(totalAmount)
-                        : totalAmount,
-                    totalFees:
-                      typeof totalFees === "number"
-                        ? `${totalFees}`
-                        : totalFees,
-                    amount: "",
-                    currency: "",
-                    totalAmountFiat: "",
-                    value: "",
-                    type: "sent",
-                    date: dayjs(payment.createdAt).fromNow(),
-                    // date: dayjs.unix(payment.createdAt),
-                    title: (
-                      <p className="truncate">
-                        <a
-                          target="_blank"
-                          title={payment.name}
-                          href={`options.html#/publishers/${allowance.id}`}
-                          rel="noreferrer"
-                        >
-                          {payment.name}
-                        </a>
-                      </p>
-                    ),
-                    subTitle: (
-                      <p className="truncate">
-                        <a
-                          target="_blank"
-                          title={payment.name}
-                          href={`options.html#/publishers/${allowance.id}`}
-                          rel="noreferrer"
-                        >
-                          {payment.host}
-                        </a>
-                      </p>
-                    ),
-                  });
-
-                  return acc;
-                },
-                []
-              )}
+                return {
+                  createdAt,
+                  description,
+                  id: `${id}`,
+                  location,
+                  name,
+                  preimage,
+                  host,
+                  totalAmount:
+                    typeof totalAmount === "string"
+                      ? parseInt(totalAmount)
+                      : totalAmount,
+                  totalFees:
+                    typeof totalFees === "number" ? `${totalFees}` : totalFees,
+                  amount: "",
+                  currency: "",
+                  totalAmountFiat: "",
+                  value: "",
+                  date: dayjs(payment.createdAt).fromNow(),
+                  // date: dayjs.unix(payment.createdAt),
+                  title: (
+                    <p className="truncate">
+                      <a
+                        target="_blank"
+                        title={payment.name}
+                        href={`options.html#/publishers/${allowance.id}`}
+                        rel="noreferrer"
+                      >
+                        {payment.name}
+                      </a>
+                    </p>
+                  ),
+                  subTitle: (
+                    <p className="truncate">
+                      <a
+                        target="_blank"
+                        title={payment.name}
+                        href={`options.html#/publishers/${allowance.id}`}
+                        rel="noreferrer"
+                      >
+                        {payment.host}
+                      </a>
+                    </p>
+                  ),
+                };
+              })}
             />
           ) : (
             <p className="text-gray-500 dark:text-neutral-400">

--- a/src/extension/background-script/actions/allowances/get.ts
+++ b/src/extension/background-script/actions/allowances/get.ts
@@ -1,5 +1,5 @@
 import db from "~/extension/background-script/db";
-import type { MessageAllowanceGet, Allowance } from "~/types";
+import type { MessageAllowanceGet, Allowance, Payment } from "~/types";
 
 const get = async (message: MessageAllowanceGet) => {
   const host = message.args.host;
@@ -31,11 +31,26 @@ const get = async (message: MessageAllowanceGet) => {
       .equalsIgnoreCase(dbAllowance.host)
       .count();
 
-    allowance.payments = await db.payments
+    // allowance.payments = await db.payments
+    //   .where("host")
+    //   .equalsIgnoreCase(dbAllowance.host)
+    //   .reverse()
+    //   .toArray();
+
+    const dbPayments = await db.payments
       .where("host")
       .equalsIgnoreCase(dbAllowance.host)
       .reverse()
       .toArray();
+
+    allowance.payments = dbPayments.reduce<Payment[]>((acc, dbPayment) => {
+      if (!dbPayment?.id) return acc;
+
+      const { id } = dbPayment;
+
+      acc.push({ ...dbPayment, id });
+      return acc;
+    }, []);
 
     allowance.paymentsAmount = allowance.payments
       .map((payment) => {

--- a/src/extension/background-script/actions/allowances/get.ts
+++ b/src/extension/background-script/actions/allowances/get.ts
@@ -8,9 +8,11 @@ const get = async (message: MessageAllowanceGet) => {
     .equalsIgnoreCase(host)
     .first();
 
-  if (dbAllowance) {
+  if (dbAllowance && dbAllowance.id) {
+    const { id } = dbAllowance;
     const allowance: Allowance = {
       ...dbAllowance,
+      id,
       payments: [],
       paymentsAmount: 0,
       paymentsCount: 0,
@@ -31,12 +33,6 @@ const get = async (message: MessageAllowanceGet) => {
       .equalsIgnoreCase(dbAllowance.host)
       .count();
 
-    // allowance.payments = await db.payments
-    //   .where("host")
-    //   .equalsIgnoreCase(dbAllowance.host)
-    //   .reverse()
-    //   .toArray();
-
     const dbPayments = await db.payments
       .where("host")
       .equalsIgnoreCase(dbAllowance.host)
@@ -45,9 +41,7 @@ const get = async (message: MessageAllowanceGet) => {
 
     allowance.payments = dbPayments.reduce<Payment[]>((acc, dbPayment) => {
       if (!dbPayment?.id) return acc;
-
       const { id } = dbPayment;
-
       acc.push({ ...dbPayment, id });
       return acc;
     }, []);

--- a/src/types.ts
+++ b/src/types.ts
@@ -318,7 +318,9 @@ export interface DbPayment {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface Payment extends DbPayment {}
+export interface Payment extends Omit<DbPayment, "id"> {
+  id: number;
+}
 
 export interface PaymentResponse
   extends Pick<Payment, "destination" | "preimage" | "paymentHash"> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -374,7 +374,8 @@ export interface DbAllowance {
   tag: string;
   totalBudget: number;
 }
-export interface Allowance extends DbAllowance {
+export interface Allowance extends Omit<DbAllowance, "id"> {
+  id: number;
   payments: Payment[];
   paymentsAmount: number;
   paymentsCount: number;


### PR DESCRIPTION
Extending internal used allowance/payment types to always have an `id`.  
db-types have an optional `id` because they type is also use to create _new_ entries which do not have an `id` before they are saved by indexie.
In this way we do not need to filter _non-id_ entries within the app just to satisfy TS. Because in the real-world scenario those will always have an id already.